### PR TITLE
do not omit empty values for required parameters

### DIFF
--- a/players.go
+++ b/players.go
@@ -37,8 +37,8 @@ type Player struct {
 
 // PlayerRequest represents a request to create/update a player.
 type PlayerRequest struct {
-	AppID             string            `json:"app_id,omitempty"`
-	DeviceType        int               `json:"device_type,omitempty"`
+	AppID             string            `json:"app_id"`
+	DeviceType        int               `json:"device_type"`
 	Identifier        string            `json:"identifier,omitempty"`
 	Language          string            `json:"language,omitempty"`
 	Timezone          int               `json:"timezone,omitempty"`


### PR DESCRIPTION
According to the OneSignal docs, the `DeviceType` property should be `0` for iOS. Having `omitempty` for that field prevents us from setting it as `0` since it will be removed when encoding into JSON.
Also, it doesn't make much sense not to set required fields.
