### PR TITLE
PlayerCSVExportOptions added: extra_fields, last_active_since

### DIFF
--- a/onesignal_test.go
+++ b/onesignal_test.go
@@ -138,10 +138,8 @@ func TestNewRequest_userKeyType(t *testing.T) {
 func TestNewRequest_invalidJSON(t *testing.T) {
 	c := NewClient(nil)
 
-	type T struct {
-		A map[int]interface{}
-	}
-	_, err := c.NewRequest("GET", "/", &T{}, APP)
+	inBody := make(chan int)
+	_, err := c.NewRequest("GET", "/", inBody, APP)
 
 	if err == nil {
 		t.Error("Expected error to be returned.")

--- a/players.go
+++ b/players.go
@@ -38,7 +38,7 @@ type Player struct {
 // PlayerRequest represents a request to create/update a player.
 type PlayerRequest struct {
 	AppID             string            `json:"app_id"`
-	DeviceType        int               `json:"device_type"`
+	DeviceType        int               `json:"device_type,omitempty"`
 	Identifier        string            `json:"identifier,omitempty"`
 	Language          string            `json:"language,omitempty"`
 	Timezone          int               `json:"timezone,omitempty"`
@@ -119,7 +119,9 @@ type PlayerOnFocusOptions struct {
 // PlayerCSVExportOptions specifies the parameters to the
 // PlayersService.CSVExport method
 type PlayerCSVExportOptions struct {
-	AppID string `json:"app_id"`
+	AppID           string      `json:"app_id"`
+	ExtraFields     interface{} `json:"extra_fields,omitempty"`
+	LastActiveSince int64       `json:"last_active_since,omitempty"`
 }
 
 // PlayerCSVExportResponse wraps the standard http.Response for the

--- a/players_test.go
+++ b/players_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/tbalthazar/onesignal-go/testhelper"
 )
@@ -377,7 +378,9 @@ func TestPlayersService_CSVExport(t *testing.T) {
 	defer teardown()
 
 	opt := &PlayerCSVExportOptions{
-		AppID: "id123",
+		AppID:           "id123",
+		ExtraFields:     []string{},
+		LastActiveSince: time.Now().Unix(),
 	}
 
 	mux.HandleFunc("/players/csv_export", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- PlayerCSVExportOptions added fields: extra_fields, last_active_since (since onesignal updated docs);
- Fixed test case of 'TestNewRequest_invalidJSON'.